### PR TITLE
Fix SocketIO chat integration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,23 +38,26 @@ def create_app(config_class=Config):
     csrf.init_app(app)
     mail.init_app(app)
     
-    # Configuración mejorada de SocketIO para Render
+    # Configuración de SocketIO usando valores de config.py
     if os.environ.get('RENDER'):
-        # Configuración específica para Render
-        socketio.init_app(app, 
-                         cors_allowed_origins="*",
-                         async_mode='threading',
-                         logger=False,
-                         engineio_logger=False,
-                         transports=['polling', 'websocket'])
+        socketio.init_app(
+            app,
+            cors_allowed_origins="*",
+            async_mode=app.config.get('SOCKETIO_ASYNC_MODE', 'threading'),
+            logger=False,
+            engineio_logger=False,
+            transports=app.config.get('SOCKETIO_TRANSPORTS', ['polling'])
+        )
         print("🔌 SocketIO configurado para Render")
     else:
-        # Configuración para desarrollo local
-        socketio.init_app(app, 
-                         cors_allowed_origins="*",
-                         async_mode='threading',
-                         logger=True,
-                         engineio_logger=True)
+        socketio.init_app(
+            app,
+            cors_allowed_origins="*",
+            async_mode=app.config.get('SOCKETIO_ASYNC_MODE', 'threading'),
+            logger=True,
+            engineio_logger=True,
+            transports=app.config.get('SOCKETIO_TRANSPORTS', ['polling', 'websocket'])
+        )
         print("🔌 SocketIO configurado para desarrollo")
     
     login.login_view = 'auth.login'

--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
-from app import create_app
+from app import create_app, socketio
 import os
 
 app = create_app()
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port, debug=False)
+    socketio.run(app, host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- align front-end SocketIO events with back-end handlers
- load chat history when joining a commission or topic
- emit messages using dedicated events
- configure SocketIO transports from `config.py`
- fix current-user detection in chat and use `socketio.run` in run.py

## Testing
- `python test_routes.py` *(fails: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_6844c5858008832e8b2772a36e2bdeb6